### PR TITLE
Update Aut2Exe.cmd

### DIFF
--- a/compile_manual/Aut2Exe.cmd
+++ b/compile_manual/Aut2Exe.cmd
@@ -1,4 +1,18 @@
 @echo off
+setlocal enabledelayedexpansion
+
+:: --- check operating system version
+for /f "tokens=3 delims=." %%b in ('ver') do set /a "win_build=%%b" 2>nul
+
+:: --- Open old console in Windows 11
+if !win_build! geq 22000 (
+	if not exist "%~dp0conhost.lock" (
+		echo. > "%~dp0conhost.lock" && start /b conhost "%~f0" & exit
+	) else (
+		del /q "%~dp0conhost.lock" 2>nul
+	)
+)
+
 mode con cols=80 lines=10
 color 3f
 title Auto2Exe Compiler


### PR DESCRIPTION
Add support in Windows 11 to fix window dimensioning with `conhost` without using the terminal

- **before**

<img width="1115" height="628" alt="1" src="https://github.com/user-attachments/assets/6b4fb624-f151-45fb-8f9f-b496ad2c717e" />

- **after**

<img width="642" height="192" alt="2" src="https://github.com/user-attachments/assets/636b0924-7ec3-4509-8f83-e727d19766b7" />
